### PR TITLE
Allow newer versions of modules

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,12 +3,12 @@ lxml >= 4.3.0
 pyVmomi (<=7.0.3,>=6.7)
 six (>=1.12)
 
-requests (==2.27.1)
-pyOpenSSL (==22.0.0)
-cryptography (==36.0.0)
-setuptools (==62.0.0)
+requests (>=2.27.1)
+pyOpenSSL (>=22.0.0)
+cryptography (>=36.0.0)
+setuptools (>=62.0.0)
 ###### SDK requirements ######
-vapi-client-bindings == 4.0.0
+vapi-client-bindings >= 4.0.0
 vmc-client-bindings
 nsx-python-sdk
 nsx-policy-python-sdk


### PR DESCRIPTION
Allowing newer versions of requests, pyOpenSSL, cryptography, setuptools, and vapi-client-bindings.